### PR TITLE
Fix mac homebrew service issues

### DIFF
--- a/Formula/seventeenlands.rb
+++ b/Formula/seventeenlands.rb
@@ -65,7 +65,7 @@ class Seventeenlands < Formula
         <key>KeepAlive</key>
         <true/>
         <key>Label</key>
-        <string>17Lands</string>
+        <string>homebrew.mxcl.seventeenlands</string>
         <key>ProgramArguments</key>
         <array>
           <string>/bin/sh</string>


### PR DESCRIPTION
Homebrew assume services are named homebrew.mxcl.<service name>, and
using a different name will confuse homebrew and cause weird errors. It
also deviates from the usual reversed-domain naming convention on Mac.

Users would need to nuke the old service manually:

launchctl remove 17Lands; rm -f ~/Library/LaunchAgents/homebrew.mxcl.seventeenlands.plist