### PR TITLE
Bump python to 3.14 and libraries to match versions in seventeenlands

### DIFF
--- a/Formula/seventeenlands.rb
+++ b/Formula/seventeenlands.rb
@@ -7,7 +7,7 @@ class Seventeenlands < Formula
   sha256 "cb3f871a8bca22ebb73aed63a3e68d24f88d88445566fb13b62cbdb558724b02"
   license "GPL-3.0"
 
-  depends_on "python@3.11"
+  depends_on "python@3.14"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/e6/de/879cf857ae6f890dfa23c3d6239814c5471936b618c8fb0c8732ad5da885/certifi-2020.11.8.tar.gz"

--- a/Formula/seventeenlands.rb
+++ b/Formula/seventeenlands.rb
@@ -10,8 +10,8 @@ class Seventeenlands < Formula
   depends_on "python@3.14"
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/e6/de/879cf857ae6f890dfa23c3d6239814c5471936b618c8fb0c8732ad5da885/certifi-2020.11.8.tar.gz"
-    sha256 "f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
+    url "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz"
+    sha256 "e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"
   end
 
   resource "chardet" do
@@ -20,18 +20,18 @@ class Seventeenlands < Formula
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz"
-    sha256 "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"
+    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
   end
 
   resource "python-dateutil" do
-    url "https://files.pythonhosted.org/packages/be/ed/5bbc91f03fa4c839c4c7360375da77f9659af5f7086b7a7bdda65771c8e0/python-dateutil-2.8.1.tar.gz"
-    sha256 "73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"
+    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
   end
 
   resource "requests" do
-    url "https://files.pythonhosted.org/packages/9f/14/4a6542a078773957aa83101336375c9597e6fe5889d20abda9c38f9f3ff2/requests-2.25.0.tar.gz"
-    sha256 "7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"
+    url "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz"
+    sha256 "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
   end
 
   resource "17lands" do
@@ -40,13 +40,13 @@ class Seventeenlands < Formula
   end
 
   resource "six" do
-    url "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz"
-    sha256 "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"
+    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
+    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/29/e6/d1a1d78c439cad688757b70f26c50a53332167c364edb0134cadd280e234/urllib3-1.26.2.tar.gz"
-    sha256 "19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"
+    url "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz"
+    sha256 "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"
   end
 
   def install


### PR DESCRIPTION
Motivated by this being the last thing keeping python@3.11 on my system, I bumped the `depends_on ` to python@3.14, then copied the package tarball locations and sha256's out of upstream [uv.lock](https://github.com/rconroy293/mtga-log-client/blob/b87160b65cfe5be1ff9f526cecacf6405147b198/src/python/uv.lock).

Spins up fine manually, service also shows no errors. I haven't tested with an actual event, but it's hard to imagine a path where that would fail under these conditions. 

Chardet is still listed as a dependency in the brew formula, but doesn't show up in uv.lock. I just left it alone. 

Longer term, it might be worth adding a github action job to keep the brew formula in sync with uv.lock.

```
$ /usr/local/bin/seventeenlands                                                                                                                                                                                                        
20260622 152533.135,INFO,retry_utils,Saving logs to /Users/paul/.seventeenlands/seventeenlands.log
20260622 152533.135,INFO,api_client,Saving logs to /Users/paul/.seventeenlands/seventeenlands.log
20260622 152533.135,INFO,17Lands,Saving logs to /Users/paul/.seventeenlands/seventeenlands.log
20260622 152533.273,INFO,17Lands,Got minimum client version response: {"is_supported":true,"latest_version":"0.1.44","min_version":"0.1.43","upgrade_instructions":""}
20260622 152533.274,INFO,17Lands,Minimum supported version: [0, 1, 43]; this version: [0, 1, 44]
20260622 152533.275,INFO,17Lands,Using token [REDACTED]
20260622 152533.275,INFO,17Lands,Parsing the previous log /Users/paul/Library/Logs/Wizards Of The Coast/MTGA/Player-prev.log once
20260622 152533.276,INFO,17Lands,Detailed logs enabled in MTGA.
20260622 152533.332,INFO,17Lands,Parsed rank info for None: {'constructedSeasonOrdinal': 88, 'constructedLevel': 4, 'limitedSeasonOrdinal': 88, 'limitedClass': 'Platinum', 'limitedLevel': 2, 'limitedStep': 1, 'limitedMatchesWon': 50, 'limitedMatchesLost': 36}
20260622 152533.497,INFO,17Lands,Submitting mastery progress
20260622 152533.625,INFO,17Lands,Submitting mastery progress
20260622 152533.756,INFO,17Lands,Updated ongoing events
20260622 152533.894,INFO,17Lands,Parsed rank info for None: {'constructedSeasonOrdinal': 90, 'constructedLevel': 4, 'limitedSeasonOrdinal': 90, 'limitedLevel': 1}
20260622 152534.026,INFO,17Lands,Updated ongoing events
20260622 152534.222,INFO,17Lands,Done processing file.
20260622 152534.222,INFO,17Lands,Following along /Users/paul/Library/Logs/Wizards Of The Coast/MTGA/Player.log
20260622 152534.223,INFO,17Lands,Detailed logs enabled in MTGA.
20260622 152534.259,INFO,17Lands,Parsed rank info for None: {'constructedSeasonOrdinal': 90, 'constructedLevel': 4, 'limitedSeasonOrdinal': 90, 'limitedLevel': 1}
20260622 152534.427,INFO,17Lands,Submitting mastery progress
20260622 152534.556,INFO,17Lands,Updated ongoing events
```